### PR TITLE
Relax composition upper bound to < 3

### DIFF
--- a/inf-backprop/inf-backprop.cabal
+++ b/inf-backprop/inf-backprop.cabal
@@ -100,7 +100,7 @@ library
     , base >=4.7 && <5
     , combinatorial <0.2
     , comonad <5.1
-    , composition <1.1
+    , composition <3
     , data-fix <0.4
     , deepseq <1.6
     , extra <1.9

--- a/inf-backprop/package.yaml
+++ b/inf-backprop/package.yaml
@@ -112,7 +112,7 @@ library:
   - transformers < 0.7
   - combinatorial < 0.2
   - comonad < 5.1
-  - composition < 1.1
+  - composition < 3
   - data-fix < 0.4
   - hashable < 1.6
   - text < 2.2

--- a/simple-expr/package.yaml
+++ b/simple-expr/package.yaml
@@ -80,7 +80,7 @@ library:
   - Stream < 0.5
   - mtl < 2.4
   - combinatorial < 0.2
-  - composition < 1.1
+  - composition < 3
   - data-fix < 0.4
   - hashable < 1.6
   - text < 2.2

--- a/simple-expr/simple-expr.cabal
+++ b/simple-expr/simple-expr.cabal
@@ -72,7 +72,7 @@ library
       Stream <0.5
     , base >=4.19 && <5
     , combinatorial <0.2
-    , composition <1.1
+    , composition <3
     , data-fix <0.4
     , graphite <0.11
     , graphviz <2999.21


### PR DESCRIPTION
Widen the `composition` dependency version bound from `< 1.1` to `< 3` in
both `simple-expr` and `inf-backprop`.

Updated in both the `package.yaml` sources and the generated `.cabal`
files. Both packages build cleanly with the loosened bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)