### PR TITLE
Telegram notifications for CI and dependency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,23 @@ jobs:
 
       - name: Build All Packages
         run: stack --resolver ${{ matrix.lts }} build --fast --haddock --test --bench --no-run-benchmarks
+
+  notify:
+    needs: build
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Telegram with CI result
+        run: |
+          case "${{ needs.build.result }}" in
+            success)   msg="✅ deep-ml CI: build & tests passed." ;;
+            failure)   msg="❌ deep-ml CI: build or tests failed." ;;
+            cancelled) msg="⚠️ deep-ml CI: run cancelled." ;;
+            *)         msg="⚠️ deep-ml CI: ${{ needs.build.result }}." ;;
+          esac
+          curl -sS -X POST \
+            "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d disable_web_page_preview=true \
+            --data-urlencode text="$msg
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/dependency-update-check.yml
+++ b/.github/workflows/dependency-update-check.yml
@@ -31,10 +31,24 @@ jobs:
         run: stack --resolver nightly build --fast --test --no-run-benchmarks
 
       - name: Check outdated dependencies for all packages
+        id: outdated
         run: |
-          cd simple-expr
-          cabal outdated
-          cd ..
-          cd inf-backprop
-          cabal outdated
-          cd ..
+          status=0
+          (cd simple-expr && cabal outdated --exit-code) || status=1
+          (cd inf-backprop && cabal outdated --exit-code) || status=1
+          exit $status
+
+      - name: Notify Telegram with dependency check result
+        if: always()
+        run: |
+          case "${{ steps.outdated.outcome }}" in
+            success) msg="✅ deep-ml: dependencies up to date." ;;
+            failure) msg="⚠️ deep-ml: outdated dependencies detected." ;;
+            *)       msg="❌ deep-ml: dependency check job failed (build/setup error)." ;;
+          esac
+          curl -sS -X POST \
+            "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d disable_web_page_preview=true \
+            --data-urlencode text="$msg
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
Adds Telegram notifications for the GitHub Actions workflows.

## dependency-update-check.yml
- Add `--exit-code` to the `cabal outdated` checks so outdated
  dependencies actually fail the job (previously they exited 0 and the
  job passed regardless).
- Always notify Telegram with the result: ✅ up to date, ⚠️ outdated
  dependencies, or ❌ build/setup error.

## ci.yml
- Add a summary `notify` job (`needs: build`, `if: always()`) that sends
  a single Telegram message per run with the overall matrix result
  (✅ passed / ❌ failed / ⚠️ cancelled), rather than one per LTS.

Both use the Telegram Bot API via `curl` and link back to the run.

## Setup required
Add two repository secrets (Settings → Secrets and variables → Actions):
- `TELEGRAM_BOT_TOKEN` — from @BotFather
- `TELEGRAM_CHAT_ID` — target chat/channel/group ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)